### PR TITLE
Fix slanglang lsp errors

### DIFF
--- a/Libs/science/slang-project.txt
+++ b/Libs/science/slang-project.txt
@@ -1,4 +1,3 @@
 
 ../base
 ../../runtime/std.slang
-../../compiler/utils

--- a/compiler1/ast.py
+++ b/compiler1/ast.py
@@ -697,7 +697,7 @@ class Module(ScopedDefinition):
         self.types = []
 
     def __repr__(self):
-        return f"Module({self.name})"
+        return f"Module({self.id.name})"
 
     def get_deps(self) -> list[str]:
         deps = [imp.modname for imp in self.imports]

--- a/compiler1/typechecker.py
+++ b/compiler1/typechecker.py
@@ -541,6 +541,7 @@ class TypeChecker(BasePass):
                 or b.is_char()
                 or b.is_enum()
                 or b.is_pointer()
+                or b.is_array()
             ):
                 # TODO: check if b contains meta-var
                 # Assign type to meta-var:

--- a/language-server/slang-lang/server.py
+++ b/language-server/slang-lang/server.py
@@ -228,8 +228,8 @@ class IncrementalCompiler:
                 filename = source[0]
                 if filename in self.module_cache:
                     m = self.module_cache[filename]
-                    if self.dependency_graph.has_node(m.name):
-                        needed_by = nx.ancestors(self.dependency_graph, m.name)
+                    if self.dependency_graph.has_node(m.id.name):
+                        needed_by = nx.ancestors(self.dependency_graph, m.id.name)
                         for n in needed_by:
                             if n in self.known_modules:
                                 dependant_filename = self.known_modules[n].filename
@@ -245,8 +245,8 @@ class IncrementalCompiler:
                 module = self.module_cache[source]
             else:
                 module = slangc.parse_file(self.id_context, source)
-                if module.name in self.known_modules:
-                    self.known_modules.pop(module.name)
+                if module.id.name in self.known_modules:
+                    self.known_modules.pop(module.id.name)
             modules.append(module)
 
         self.dependency_graph = slangc.dependency_graph(modules)
@@ -254,7 +254,7 @@ class IncrementalCompiler:
 
         # Analyze modules:
         for module in modules:
-            if module.name in self.known_modules:
+            if module.id.name in self.known_modules:
                 continue
             slangc.resolve_names(self.known_modules, module)
             slangc.evaluate_types(module)

--- a/tests/slang-project.txt
+++ b/tests/slang-project.txt
@@ -7,4 +7,3 @@
 ../Libs/regex/rangelib.slang
 ../Libs/regex/regex.slang
 ../runtime/std.slang
-../compiler/utils


### PR DESCRIPTION
- `server.py` was missed during a refactor from `module.name` to `module.id.name`
- `ast.py` did not support unification with `Meta` and `Array` -> @windelbouwman is this fix this correct?
- There were warnings about missing folders in `slang-project.txt`, they do not exist anymore.

The slang-lang lsp works in helix after these changes. Helix correctly uses the `.helix/languages.toml`.

Tip: You can use `tail -f ~/.cache/helix/helix.log` to view the lsp debug messages while using helix.